### PR TITLE
chore: v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.5.2 (Jan 9, 2020)
+
+ * chore: Switched to new `appcd.apiVersion`.
+   [(DAEMON-309)](https://jira.appcelerator.org/browse/DAEMON-309)
+ * chore: Updated dependencies.
+
 # v1.5.1 (Nov 8, 2019)
 
  * chore: Update dependencies.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019 by Axway, Inc.
+Copyright 2017-2020 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-ios",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "iOS service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,19 +16,19 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.6",
-    "ioslib": "^2.5.2",
-    "semver": "^6.3.0",
+    "gawk": "^4.7.0",
+    "ioslib": "^2.5.5",
+    "semver": "^7.1.1",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.3.0"
+    "appcd-gulp": "^2.3.1"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon-plugins/tree/master/packages/appcd-plugin-ios",
   "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
   "repository": "https://github.com/appcelerator/appc-daemon-plugins",
   "appcd": {
-    "appcdVersion": "1.x || 2.x || 3.x",
+    "apiVersion": "1.x",
     "config": "./conf/config.js",
     "name": "ios",
     "os": [


### PR DESCRIPTION
chore: Switched to new 'appcd.apiVersion'.
chore: Updated npm deps.