### PR TITLE
chore: v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.2 (Jan 9, 2020)
+
+ * chore: Switched to new `appcd.apiVersion`.
+   [(DAEMON-309)](https://jira.appcelerator.org/browse/DAEMON-309)
+ * chore: Updated dependencies.
+
 # v2.0.1 (Nov 10, 2019)
 
  * fix: Fixed appcd version in `package.json`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019 by Axway, Inc.
+Copyright 2017-2020 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-ios",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "iOS service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,19 +16,19 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.6",
-    "ioslib": "^3.2.1",
-    "semver": "^6.3.0",
+    "gawk": "^4.7.0",
+    "ioslib": "^3.2.5",
+    "semver": "^7.1.1",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.3.0"
+    "appcd-gulp": "^2.3.1"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon",
   "bugs": "https://github.com/appcelerator/appcd-plugin-ios/issues",
   "repository": "https://github.com/appcelerator/appcd-plugin-ios",
   "appcd": {
-    "appcdVersion": "3.x",
+    "apiVersion": "^1.1.0",
     "config": "./conf/config.js",
     "name": "ios",
     "os": [


### PR DESCRIPTION
chore: Switched to new 'appcd.apiVersion'.
chore: Updated npm deps.